### PR TITLE
Edit to readthedocs.io -- Adding Hyperlink of Internal reference for appendixD.rst

### DIFF
--- a/docs/source/user/subdyn/appendixD.rst
+++ b/docs/source/user/subdyn/appendixD.rst
@@ -7,7 +7,7 @@ This is a list of all possible output parameters for the SubDyn module.
 The names are grouped by meaning, but can be ordered in the OUTPUT
 CHANNELS section of the SubDyn input file as the user sees fit. :math:`M \alpha N \beta`,
 refers to node :math:`\beta` of member :math:`\alpha`, where :math:`\alpha` is a number in the range [1,9] and
-corresponds to row :math:`\alpha` in the MEMBER OUTPUT LIST table (see :numref:`_SD_Member_Output`) and
+corresponds to row :math:`\alpha` in the MEMBER OUTPUT LIST table (see :numref:`SD_Member_Output`) and
 :math:`\beta` is a number in the range [1,9] and corresponds to node :math:`\beta` in the
 **NodeCnt** list of that table entry.
 

--- a/docs/source/user/subdyn/appendixD.rst
+++ b/docs/source/user/subdyn/appendixD.rst
@@ -7,7 +7,7 @@ This is a list of all possible output parameters for the SubDyn module.
 The names are grouped by meaning, but can be ordered in the OUTPUT
 CHANNELS section of the SubDyn input file as the user sees fit. :math:`M \alpha N \beta`,
 refers to node :math:`\beta` of member :math:`\alpha`, where :math:`\alpha` is a number in the range [1,9] and
-corresponds to row :math:`\alpha` in the MEMBER OUTPUT LIST table (see Section ) and
+corresponds to row :math:`\alpha` in the MEMBER OUTPUT LIST table (see :numref:`_SD_Member_Output`) and
 :math:`\beta` is a number in the range [1,9] and corresponds to node :math:`\beta` in the
 **NodeCnt** list of that table entry.
 


### PR DESCRIPTION
Added a missing reference link about MEMBER OUTPUT LISTS to the relevant page from the readthedocs.io site (https://openfast.readthedocs.io/en/dev/source/user/subdyn/input_files.html#member-output-list). 

Adhered to the referencing conventions used throughout the readthedocs.io